### PR TITLE
[Enhancement] Remove material glow on over-scroll

### DIFF
--- a/lib/Components/scroll_behaviour.dart
+++ b/lib/Components/scroll_behaviour.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+/// Removes the material glow behaviour which was default for
+/// overscroll on Android
+class ScrollWithoutMaterialOverflowGlow extends ScrollBehavior {
+  @override
+  Widget buildViewportChrome(
+      BuildContext context, Widget child, AxisDirection axisDirection) {
+    return child;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:elemental/Components/scroll_behaviour.dart';
 import 'package:elemental/pages/Splash.dart';
 import 'package:flutter/material.dart';
 
@@ -25,6 +26,7 @@ class _MyAppState extends State<MyApp> {
         primarySwatch: Colors.green,
       ),
       home: Splash(),
+      scrollBehavior: ScrollWithoutMaterialOverflowGlow(),
     );
   }
 }


### PR DESCRIPTION
I noticed that on scrolling beyond extent on my android phone, the default 'glow' effect was in play. I figured this did not fit in well with the look of the app. 
So here's a little contribution from my side. Great project by the way xD


### Samples
- Before the change:

https://user-images.githubusercontent.com/37346450/127169704-ccbe23e8-a373-45cf-9ecd-f1300e7613e7.mp4

- After the change

https://user-images.githubusercontent.com/37346450/127169308-99009ea6-613b-4c6a-bee5-4a63f994f177.mp4


